### PR TITLE
filter against full names/types, not truncated

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -15,6 +15,7 @@
   * Sylvain Laperche
   * Tobias Patzl
   * Michiel Pater
+  * George Angelopoulos
 
 ## TRANSLATORS:
 

--- a/src/dfc.c
+++ b/src/dfc.c
@@ -544,11 +544,11 @@ disp(struct list *lst, const char *fstfilter, const char *fsnfilter,
 		}
 
 		/* filtering on fs type */
-		if (tflag && (fsfilter(p->fstype, fstfilter, nmt) == 0)) {
+		if (tflag && (fsfilter(p->fstypeog, fstfilter, nmt) == 0)) {
 			continue;
 		}
 		/* filtering on fs name */
-		if (pflag && (fsfilter(p->fsname, fsnfilter, nmn) == 0)) {
+		if (pflag && (fsfilter(p->fsnameog, fsnfilter, nmn) == 0)) {
 			continue;
 		}
 

--- a/src/list.c
+++ b/src/list.c
@@ -109,8 +109,11 @@ fmi_init(void)
 	struct fsmntinfo fmi;
 
 	fmi.fsname  = g_unknown_str;
+	fmi.fsnameog  = g_unknown_str;
 	fmi.fstype  = g_unknown_str;
+	fmi.fstypeog  = g_unknown_str;
 	fmi.mntdir  = g_unknown_str;
+	fmi.mntdirog  = g_unknown_str;
 	fmi.mntopts = g_none_str;
 
 	fmi.perctused = 0.0;

--- a/src/list.h
+++ b/src/list.h
@@ -45,8 +45,11 @@
 struct fsmntinfo {
 	/* infos to get from getmntent(3) */
 	char *fsname;	/* name of mounted file system */
+	char *fsnameog; /* original name of file system */
 	char *fstype;	/* mount type */
+	char *fstypeog;	/* original mount type */
 	char *mntdir;	/* file system path prefix */
+	char *mntdirog;	/* original file system path prefix */
 	char *mntopts;	/* mount options (see mntent.h) */
 
 	double perctused;   /* fs usage in % */

--- a/src/platform/services-bsd.c
+++ b/src/platform/services-bsd.c
@@ -121,13 +121,16 @@ fetch_info(struct list *lst)
 
 	for (fs = &entbuf; nummnt--; (*fs)++) {
 		vfsbuf = **fs;
+		if ((fmi->fsnameog = strdup(entbuf->f_mntfromname)) == NULL)
+			fmi->fsnameog = g_unknown_str;
+		if ((fmi->mntdirog = strdup(entbuf->f_mntonname)) == NULL)
+			fmi->mntdirog = g_unknown_str;
+		if ((fmi->fstypeog = strdup(entbuf->f_fstypename)) == NULL)
+			fmi->fstypeog = g_unknown_str;
 		if (Wflag) { /* Wflag to avoid name truncation */
-			if ((fmi->fsname = strdup(entbuf->f_mntfromname)) == NULL)
-				fmi->fsname = g_unknown_str;
-			if ((fmi->mntdir = strdup(entbuf->f_mntonname)) == NULL)
-				fmi->mntdir = g_unknown_str;
-			if ((fmi->fstype = strdup(entbuf->f_fstypename)) == NULL)
-				fmi->fstype = g_unknown_str;
+			fmi->fsname = fmi->fsnameog;
+			fmi->mntdir = fmi->mntdirog;
+			fmi->fstype = fmi->fstypeog;
 		} else {
 			if ((fmi->fsname = strdup(shortenstr(
 				entbuf->f_mntfromname, STRMAXLEN))) == NULL) {

--- a/src/platform/services-linux.c
+++ b/src/platform/services-linux.c
@@ -114,13 +114,16 @@ fetch_info(struct list *lst)
 			continue;
 		}
 		/* infos from getmntent */
+		if ((fmi->fsnameog = strdup(entbuf->mnt_fsname)) == NULL)
+			fmi->fsnameog = g_unknown_str;
+		if ((fmi->mntdirog = strdup(entbuf->mnt_dir)) == NULL)
+			fmi->mntdirog = g_unknown_str;
+		if ((fmi->fstypeog = strdup(entbuf->mnt_type)) == NULL)
+			fmi->fstypeog = g_unknown_str;
 		if (Wflag) { /* Wflag to avoid name truncation */
-			if ((fmi->fsname = strdup(entbuf->mnt_fsname)) == NULL)
-				fmi->fsname = g_unknown_str;
-			if ((fmi->mntdir = strdup(entbuf->mnt_dir)) == NULL)
-				fmi->mntdir = g_unknown_str;
-			if ((fmi->fstype = strdup(entbuf->mnt_type)) == NULL)
-				fmi->fstype = g_unknown_str;
+			fmi->fsname = fmi->fsnameog;
+			fmi->mntdir = fmi->mntdirog;
+			fmi->fstype = fmi->fstypeog;
 		} else {
 			if ((fmi->fsname = strdup(shortenstr(
 				entbuf->mnt_fsname, STRMAXLEN))) == NULL) {

--- a/src/platform/services-solaris.c
+++ b/src/platform/services-solaris.c
@@ -110,13 +110,16 @@ fetch_info(struct list *lst)
 			perror(" ");
 			continue;
 		}
+		if ((fmi->fsnameog = strdup(mnttabbuf.mnt_special)) == NULL)
+			fmi->fsnameog = g_unknown_str;
+		if ((fmi->mntdirog = strdup(mnttabbuf.mnt_mountp))== NULL)
+			fmi->mntdirog = g_unknown_str;
+		if ((fmi->fstypeog = strdup(mnttabbuf.mnt_fstype)) == NULL)
+			fmi->fstypeog = g_unknown_str;
 		if (Wflag) { /* Wflag to avoid name truncation */
-			if ((fmi->fsname = strdup(mnttabbuf.mnt_special)) == NULL)
-				fmi->fsname = g_unknown_str;
-			if ((fmi->mntdir = strdup(mnttabbuf.mnt_mountp))== NULL)
-				fmi->mntdir = g_unknown_str;
-			if ((fmi->fstype = strdup(mnttabbuf.mnt_fstype)) == NULL)
-				fmi->fstype = g_unknown_str;
+			fmi->fsname = fmi->fsnameog;
+			fmi->mntdir = fmi->mntdirog;
+			fmi->fstype = fmi->fstypeog;
 		} else {
 			if ((fmi->fsname = strdup(shortenstr(
 				mnttabbuf.mnt_special, STRMAXLEN))) == NULL) {


### PR DESCRIPTION
This patch makes dfc store the original fsname, fstype, and mntdir
in seperate variables before truncating them so that we can use either.

Also, name and type filtering now filters against these newly added
"og" variables.

This is essentially one proposed fix for the issue I point out in https://projects.gw-computing.net/issues/134.

If you would like to get rid of the truncation altogether, thus rendering this patch obsolete, that's also cool with me. 👍 

**ONLY TESTED ON LINUX**
I did not compile and test on bsd or solaris.