### PR TITLE
text header: prevent unwanted color pollution of the next line.

### DIFF
--- a/src/export/text.c
+++ b/src/export/text.c
@@ -132,9 +132,10 @@ text_disp_header(void)
 
 	if (oflag)
 		(void)printf("%-*s", max.mntopts, _("MOUNT OPTIONS"));
-	(void)printf("\n");
-
+	/* reset color before newline to prevent unwanted pollution of the next line */
 	reset_color();
+
+	(void)printf("\n");
 }
 
 /*


### PR DESCRIPTION
Hello,

This patch fixes a minor visual annoyance that shows up when one attempts to prefix the colored output of dfc, e.g.:
`bin/dfc  -W -c always | sed 's/^/prefix: /'`